### PR TITLE
Add: autowrap feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ import workerAPI from "comlink:./worker.js";
 
 - `marker`: A string that is used as a prefix to mark a worker import. Default is `comlink`.
 - `useModuleWorkers`: Use module workers (requires `{format: "esm"}`).
+- `autoWrap`: A list of regex. Modules whose id matches the regex will be wrapped by comlink automatically.
 
 ## TypeScript
 

--- a/autowrap.js
+++ b/autowrap.js
@@ -14,6 +14,7 @@ async function autoWrap({ code, ast, shouldAutoWrap, prefix }) {
 
   const refToProp = new Map();
 
+  let dirty = false;
   for (const node of ast.body) {
     // FIXME: currently we don't handle export from statement
     if (
@@ -37,10 +38,11 @@ async function autoWrap({ code, ast, shouldAutoWrap, prefix }) {
           `${prefix}${node.source.value}`
         )}`
       );
+      dirty = true;
     }
   }
 
-  if (!refToProp.size) return;
+  if (!dirty) return;
 
   let scope = attachScopes(ast, "scope");
 

--- a/autowrap.js
+++ b/autowrap.js
@@ -1,0 +1,73 @@
+const MagicString = require("magic-string");
+const isReference = require("is-reference");
+const { attachScopes } = require("@rollup/pluginutils");
+const { walk } = require("estree-walker");
+
+let inc = 1;
+
+function generateWorkerName() {
+  return `__comlink_import${inc++}`;
+}
+
+async function autoWrap({ code, ast, shouldAutoWrap, prefix }) {
+  code = new MagicString(code);
+
+  const refToProp = new Map();
+
+  for (const node of ast.body) {
+    // FIXME: currently we don't handle export from statement
+    if (
+      node.type === "ImportDeclaration" &&
+      (await shouldAutoWrap(node.source.value))
+    ) {
+      const workerName =
+        node.specifiers.find((s) => s.type === "ImportNamespaceSpecifier")
+          ?.local.name || generateWorkerName();
+      for (const spec of node.specifiers) {
+        if (spec.type === "ImportDefaultSpecifier") {
+          refToProp.set(spec.local.name, `${workerName}.default`);
+        } else if (spec.type === "ImportSpecifier") {
+          refToProp.set(spec.local.name, `${workerName}.${spec.imported.name}`);
+        }
+      }
+      code.overwrite(
+        node.start,
+        node.end,
+        `import ${workerName} from ${JSON.stringify(
+          `${prefix}${node.source.value}`
+        )}`
+      );
+    }
+  }
+
+  if (!refToProp.size) return;
+
+  let scope = attachScopes(ast, "scope");
+
+  walk(ast, {
+    enter(node, parent) {
+      if (node.type === "ImportDeclaration") this.skip();
+
+      if (node.scope) scope = node.scope;
+
+      if (
+        node.type === "Identifier" &&
+        refToProp.has(node.name) &&
+        isReference(node, parent) &&
+        !scope.contains(node.name)
+      ) {
+        code.overwrite(node.start, node.end, refToProp.get(node.name));
+      }
+    },
+    leave(node) {
+      if (node.scope) scope = node.scope.parent;
+    },
+  });
+
+  return {
+    code: code.toString(),
+    map: code.generateMap(),
+  };
+}
+
+module.exports = { autoWrap };

--- a/index.js
+++ b/index.js
@@ -14,9 +14,12 @@
 const { readFileSync } = require("fs");
 const { join } = require("path");
 
+const { autoWrap } = require("./autowrap");
+
 const defaultOpts = {
   marker: "comlink",
   useModuleWorker: false,
+  autoWrap: [],
 };
 
 function generateLoaderModule(path, { useModuleWorker = false } = {}) {
@@ -57,6 +60,21 @@ module.exports = function (opts = {}) {
       if (!newId) throw Error(`Cannot find module '${path}'`);
 
       return prefix + newId;
+    },
+
+    transform(code, id) {
+      const ast = this.parse(code);
+      return autoWrap({
+        code,
+        ast,
+        prefix,
+        shouldAutoWrap: async (importee) => {
+          const result = await this.resolve(importee, id);
+          return (
+            result && result.id && opts.autoWrap.some((r) => r.test(result.id))
+          );
+        },
+      });
     },
 
     outputOptions({ format }) {

--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ module.exports = function (opts = {}) {
     },
 
     transform(code, id) {
+      if (id.endsWith(suffix) || id.startsWith("\0")) return;
       const ast = this.parse(code);
       return autoWrap({
         code,

--- a/package.json
+++ b/package.json
@@ -42,5 +42,11 @@
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --write"
+  },
+  "dependencies": {
+    "@rollup/pluginutils": "^3.1.0",
+    "estree-walker": "^1.0.1",
+    "is-reference": "^1.2.1",
+    "magic-string": "^0.25.7"
   }
 }

--- a/run_tests.js
+++ b/run_tests.js
@@ -33,12 +33,13 @@ async function init() {
     [
       "./tests/fixtures/simple-bundle/entry.js",
       "./tests/fixtures/module-worker/entry.js",
-      "./tests/fixtures/destructuring/entry.js"
-    ].map(async input => {
+      "./tests/fixtures/destructuring/entry.js",
+      "./tests/fixtures/auto-wrap/entry.js",
+    ].map(async (input) => {
       const pathName = path.dirname(input);
       const outputOptions = {
         dir: path.join(pathName, "build"),
-        format: "es"
+        format: "es",
       };
       const rollupConfigPath = "./" + path.join(pathName, "rollup.config.js");
       let rollupConfig = require(rollupConfigPath);
@@ -51,9 +52,9 @@ async function init() {
   myKarmaConfig({
     set(config) {
       Object.assign(karmaConfig, config);
-    }
+    },
   });
-  const server = new karma.Server(karmaConfig, code => {
+  const server = new karma.Server(karmaConfig, (code) => {
     console.log(`Karma exited with code ${code}`);
     process.exit(code);
   });

--- a/tests/auto-wrap.test.js
+++ b/tests/auto-wrap.test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Comlink plugin", function () {
+  beforeEach(function () {
+    this.ifr = document.createElement("iframe");
+    document.body.append(this.ifr);
+  });
+
+  afterEach(function () {
+    this.ifr.remove();
+  });
+
+  it("proxies workers (auto-wrap)", function (done) {
+    window.addEventListener("message", function l(ev) {
+      if (ev.data === "a") {
+        window.removeEventListener("message", l);
+        done();
+      }
+    });
+    this.ifr.src = "/base/tests/fixtures/auto-wrap/build/runner.html";
+  });
+});

--- a/tests/fixtures/auto-wrap/a.js
+++ b/tests/fixtures/auto-wrap/a.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function f() {
+  return "a";
+}

--- a/tests/fixtures/auto-wrap/build/runner.html
+++ b/tests/fixtures/auto-wrap/build/runner.html
@@ -1,0 +1,15 @@
+<!--
+Copyright 2018 Google Inc. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!doctype html>
+<script src="entry.js"></script>

--- a/tests/fixtures/auto-wrap/entry.js
+++ b/tests/fixtures/auto-wrap/entry.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { f } from "./a.js";
+
+(async function () {
+  const v = await f();
+  window.parent.postMessage(v);
+})();

--- a/tests/fixtures/auto-wrap/rollup.config.js
+++ b/tests/fixtures/auto-wrap/rollup.config.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const omt = require("@surma/rollup-plugin-off-main-thread");
+const comlink = require("../../../");
+const resolve = require("@rollup/plugin-node-resolve").nodeResolve;
+
+module.exports = {
+  input: `${__dirname}/entry.js`,
+  output: {
+    dir: `${__dirname}/build`,
+    format: "amd",
+  },
+  plugins: [
+    resolve(),
+    comlink({
+      autoWrap: [/\ba\.js$/],
+    }),
+    omt(),
+  ],
+};


### PR DESCRIPTION
Fixes #1.

This PR adds new option `autoWrap: Array<RegExp>`. If a module e.g. `worker.js` matches the regex, other modules depending on it will be converted from
```js
import {foo} from "./worker.js";`
await foo();
```
to
```js
import __comlink_import1 from "comlink:./worker.js"
await __comlink_import1.foo();
```
