### PR TITLE
Fix new Worker() path

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ function generateLoaderModule(path, { useModuleWorker = false } = {}) {
 		import workerPath from ${JSON.stringify(`omt:${path}`)};
 		import {wrap} from "comlink";
 
-		export default wrap(new Worker(workerPath${
+		const currentImportPath = (new URL(import.meta.url).pathname.match(/(^\/.+)*\//g) || [""])[0];
+		export default wrap(new Worker(currentImportPath + workerPath${
       useModuleWorker ? `, {type: "module"}` : ""
     }));
 	`;

--- a/index.js
+++ b/index.js
@@ -24,8 +24,7 @@ function generateLoaderModule(path, { useModuleWorker = false } = {}) {
 		import workerPath from ${JSON.stringify(`omt:${path}`)};
 		import {wrap} from "comlink";
 
-		const currentImportPath = (new URL(import.meta.url).pathname.match(/(^\\/.+)*\\//g) || [""])[0];
-		export default wrap(new Worker(currentImportPath + workerPath${
+		export default wrap(new Worker(new URL(workerPath, import.meta.url)${
       useModuleWorker ? `, {type: "module"}` : ""
     }));
 	`;

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function generateLoaderModule(path, { useModuleWorker = false } = {}) {
 		import workerPath from ${JSON.stringify(`omt:${path}`)};
 		import {wrap} from "comlink";
 
-		const currentImportPath = (new URL(import.meta.url).pathname.match(/(^\/.+)*\//g) || [""])[0];
+		const currentImportPath = (new URL(import.meta.url).pathname.match(/(^\\/.+)*\\//g) || [""])[0];
 		export default wrap(new Worker(currentImportPath + workerPath${
       useModuleWorker ? `, {type: "module"}` : ""
     }));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "@surma/rollup-plugin-off-main-thread": "^1.4.1",
+    "@surma/rollup-plugin-off-main-thread": "2.2.2",
     "chai": "4.2.0",
     "comlink": "^4.3.0",
     "husky": "^4.3.0",
@@ -32,7 +32,7 @@
     "url": "https://github.com/surma/rollup-plugin-comlink"
   },
   "peerDependencies": {
-    "@surma/rollup-plugin-off-main-thread": ">=1",
+    "@surma/rollup-plugin-off-main-thread": ">=2",
     "comlink": ">=4"
   },
   "husky": {

--- a/tests/fixtures/destructuring/build/runner.html
+++ b/tests/fixtures/destructuring/build/runner.html
@@ -12,4 +12,4 @@ limitations under the License.
 -->
 
 <!doctype html>
-<script type="module" src="entry.js"></script>
+<script src="entry.js"></script>


### PR DESCRIPTION
Work out the import path of the current script on run time and prepend it to the importing URL so that it still works when the build directory is different from the HTML page loading the file.